### PR TITLE
Updated DE and FR page footer links to new website URLs

### DIFF
--- a/translations/sumofus.de.yml
+++ b/translations/sumofus.de.yml
@@ -63,10 +63,10 @@ de:
     privacy_policy: Datenschutz
     contact: Kontakt (Impressum)
     controlshift: '' #intentionally left blank
-    home_url: http://de.sumofus.org/
-    about_url: http://de.sumofus.org/uber-uns
-    privacy_policy_url: https://sumofus.org/de/datenschutz/
-    contact_url: http://de.sumofus.org/impressum
+    home_url: https://www.sumofus.org/de/
+    about_url: https://www.sumofus.org/de/about/
+    privacy_policy_url: https://www.sumofus.org/de/privacy/
+    contact_url: https://www.sumofus.org/de/contact/
   baysanto:
     header:
       tagline: 'Menschen engagieren sich bereits gegen die Übernahme'

--- a/translations/sumofus.fr.yml
+++ b/translations/sumofus.fr.yml
@@ -63,7 +63,7 @@ fr:
     privacy_policy: Mentions Légales
     contact: Contact
     controlshift: Lancez votre propre pétition
-    home_url: http://fr.sumofus.org/
-    about_url: http://fr.sumofus.org/a-propos
-    privacy_policy_url: http://fr.sumofus.org/politique-de-confidentialite
-    contact_url: http://fr.sumofus.org/contact
+    home_url: https://www.sumofus.org/fr/
+    about_url: https://www.sumofus.org/fr/about/
+    privacy_policy_url: https://www.sumofus.org/fr/privacy/
+    contact_url: https://www.sumofus.org/fr/contact/


### PR DESCRIPTION
We had fr.sumofus.org and de.sumofus.org tumblr sites linked in our DE and FR action page footers for a couple of months. Those sites aren't needed now that we have launched the new www.sumofus.org site.