### PR TITLE
fix cover-photo__overlay z-index which was overlapping UI components

### DIFF
--- a/stylesheets/pages/caller.scss
+++ b/stylesheets/pages/caller.scss
@@ -1,5 +1,5 @@
 .cover-photo__overlay {
-  z-index: 1000;
+  z-index: 300;
 }
 
 .caller-header {


### PR DESCRIPTION
@rodrei this is your line, it was making the title container be z-indexed over the top part of the mobile view of the fundraiser. I'm going to release this today, since it's a bugfix and I don't see any problems on the phone call view.