### PR TITLE
Small style fix for caller template

### DIFF
--- a/stylesheets/components/photos.scss
+++ b/stylesheets/components/photos.scss
@@ -16,7 +16,7 @@
   background-position: center;
   &__overlay {
     position: absolute;
-    z-index: 10;
+    z-index: 300;
     top: 0;
     left: 0;
     right: 0;

--- a/stylesheets/pages/caller.scss
+++ b/stylesheets/pages/caller.scss
@@ -1,7 +1,3 @@
-.cover-photo__overlay {
-  z-index: 300;
-}
-
 .caller-header {
   @media(max-width: $mobile-width) {
     display: none;
@@ -68,6 +64,7 @@
       @include mobile-full-width();
       max-width: 350px;
       margin: 30px auto 0 auto;
+      z-index: 0;
 
       .form__group {
         margin-bottom: 15px;


### PR DESCRIPTION
Before this fix, the form used to be displayed on top of the header bar. Now it's below as expected. 

![screen shot 2017-03-01 at 12 12 06 pm](https://cloud.githubusercontent.com/assets/278462/23465880/5004676c-fe78-11e6-8dad-dd47b3dba707.png)

I also moved a style from caller.scss to photos.scss where it belongs. 