### PR TITLE
Added petition-and-scroll-to-share template

### DIFF
--- a/stylesheets/pages/petition-and-scroll-to-share.scss
+++ b/stylesheets/pages/petition-and-scroll-to-share.scss
@@ -1,0 +1,4 @@
+.petition-and-scroll-to-share__share-wrapper {
+  display: none;
+  margin-top: -70px;
+}

--- a/stylesheets/pages/petition-and-scroll-to-share.scss
+++ b/stylesheets/pages/petition-and-scroll-to-share.scss
@@ -6,4 +6,51 @@
   &__share-wrapper {
     display: none;
   }
+
+  &__fundraiser-wrapper {
+    display: none;
+    padding-top: 97px;
+
+    h1.intro {
+      font-size: 24px;
+      line-height:1.2;
+      max-width: 700px;
+      text-align: center;
+      margin: 0 auto;
+    }
+
+    .fundraiser-bar__top h2 {
+      font-size: 42px;
+    }
+
+    .fundraiser-bar, .FundraiserView-container {
+      max-width: 700px;
+
+      .StepContent {
+        max-width: 500px;
+      }
+    }
+
+    .submission-interstitial {
+      margin-top: 30px;
+    }
+  }
+
+
+  @media(max-width: $mobile-width) {
+
+    &__fundraiser-wrapper {
+      padding-top: 0;
+
+      h1.intro {
+        font-size: 12px;
+        color: #b2b5ba;
+      }
+
+      .fundraiser-bar__top h2 {
+        font-size: 24px;
+      }
+    }
+
+  }
 }

--- a/stylesheets/pages/petition-and-scroll-to-share.scss
+++ b/stylesheets/pages/petition-and-scroll-to-share.scss
@@ -1,4 +1,9 @@
-.petition-and-scroll-to-share__share-wrapper {
-  display: none;
-  margin-top: -70px;
+.petition-and-scroll-to-share {
+  &__yes-no-question-wrapper {
+    display: none;
+  }
+
+  &__share-wrapper {
+    display: none;
+  }
 }

--- a/templates/layouts/petition-and-scroll-to-share.liquid
+++ b/templates/layouts/petition-and-scroll-to-share.liquid
@@ -59,14 +59,22 @@
   </div>
 </div>
 
+<div class="center-content petition-and-scroll-to-share__fundraiser-wrapper">
+  <h1 class="thank-you__cta intro"> {{ 'petition_and_scroll.fundraiser_intro' | t }} </h1>
+  {% capture fundraiser_title %} {{ 'share_and_donate.fundraiser_title' | t }} {% endcapture %}
+  {% include 'Fundraiser Refactor', freestanding: true, fundraiser_title: fundraiser_title %}
+</div>
+
 {% include 'Petition Mobile Footer' %}
 {% include 'Small Image Footer' %}
 
 <script type="text/javascript">
   $(document).ready(function(){
+    var petitionOverlayButton = $('.petition-bar__mobile_ui__bottom_bar');
     var petitionSidebar = $('.center-content__fixed-right');
     var yesNoQuestion = $('.petition-and-scroll-to-share__yes-no-question-wrapper');
     var shareStep = $('.petition-and-scroll-to-share__share-wrapper');
+    var fundraiserStep = $('.petition-and-scroll-to-share__fundraiser-wrapper');
 
     new window.champaign.Petition({
       redirectAfterAction: false,
@@ -76,26 +84,47 @@
     $('.two-step__accept').click(displayAndScrollToShare);
     $('.two-step__decline').click(displayAndScrollToDonate);
 
+    function makeStepFullScreen(stepElement) {
+      var offset = 35;
+      var padding = parseInt(stepElement.css('padding-top'));
+      var totalElementHeight = stepElement.height() + padding + offset
+      if (totalElementHeight < window.innerHeight) {
+        stepElement.css('margin-bottom', window.innerHeight - totalElementHeight);
+      }
+      // Fix step height
+      stepElement.css('height', stepElement.height());
+    }
+
     function petitionCallback(e, data) {
       petitionSidebar.fadeOut();
-      yesNoQuestion.css('margin-bottom', window.innerHeight - yesNoQuestion.height());
+      petitionOverlayButton.fadeOut();
+      displayAndScrollToYesNoQuestion();
+    }
+
+    function displayAndScrollToYesNoQuestion() {
+      makeStepFullScreen(yesNoQuestion);
       yesNoQuestion.fadeIn();
       scrollTo(yesNoQuestion);
     }
 
     function displayAndScrollToShare() {
+      makeStepFullScreen(shareStep);
       shareStep.fadeIn();
-      shareStep.css('margin-bottom', window.innerHeight - shareStep.height());
       scrollTo(shareStep);
     }
 
     function displayAndScrollToDonate() {
-      alert('donate');
+      makeStepFullScreen(fundraiserStep);
+      fundraiserStep.fadeIn();
+      scrollTo(fundraiserStep);
     }
 
     function scrollTo(element) {
       $('html, body').animate({scrollTop: element.offset().top}, 800);
     }
 
+    $.subscribe('fundraiser:transaction_success', function(event, responseData, formData) {
+      window.champaign.redirectors.AfterDonationRedirector.attemptRedirect("{{ follow_up_url }}", formData);
+    });
   });
 </script>

--- a/templates/layouts/petition-and-scroll-to-share.liquid
+++ b/templates/layouts/petition-and-scroll-to-share.liquid
@@ -87,7 +87,7 @@
     function makeStepFullScreen(stepElement) {
       var offset = 35;
       var padding = parseInt(stepElement.css('padding-top'), 10);
-      var totalElementHeight = stepElement.height() + padding + offset
+      var totalElementHeight = stepElement.height() + padding + offset;
       if (totalElementHeight < window.innerHeight) {
         stepElement.css('margin-bottom', window.innerHeight - totalElementHeight);
       }

--- a/templates/layouts/petition-and-scroll-to-share.liquid
+++ b/templates/layouts/petition-and-scroll-to-share.liquid
@@ -1,0 +1,52 @@
+{% comment %} Description: Petition page that scrolls down to share. {% endcomment %}
+{% comment %} Primary layout: true {% endcomment %}
+
+{% include 'Small Header' %}
+
+<div class="center-content center-content--accomodates-stuck-footer petition-and-scroll-to-share__sidebar">
+  <div class="center-content__big-column">
+    <div class="mobile-show pre-main-bar">{% include 'Thermometer' %}</div>
+
+    {% include 'Body Text' %}
+  </div>
+  <div class="center-content__fixed-right center-content--push-down">
+    {% include 'Petition Sidebar', extra_class: 'stuck-right not-sticky' %}
+  </div>
+</div>
+
+<div class="center-content center-content--accomodates-stuck-footer petition-and-scroll-to-share__share-wrapper">
+  <div class="center-content__one-column">
+
+    <div class="center-content__central-square">
+
+      {% capture message %}{{ 'petition.thank_you' | val: 'petition_title', title | t }}{% endcapture %}
+      <h1 class="thank-you__thanks">{{ message }}</h1>
+      <div class="thank-you__cta">{{ 'share.cta' | t }}</div>
+
+      <div class="center-content__centered-element">
+        {% include 'Share' %}
+      </div>
+    </div>
+
+  </div>
+</div>
+
+{% include 'Petition Mobile Footer' %}
+{% include 'Small Image Footer' %}
+
+<script type="text/javascript">
+  $(document).ready(function(){
+    var callback = function(e, data) {
+      var petitionSidebar = $('.center-content__fixed-right');
+      var bottomShare = $('.petition-and-scroll-to-share__share-wrapper');
+      petitionSidebar.fadeOut();
+      bottomShare.fadeIn();
+      $('html, body').animate({scrollTop: bottomShare.offset().top}, 800);
+    }
+
+    new window.champaign.Petition({
+      redirectAfterAction: false,
+      submissionCallback: callback
+    });
+  });
+</script>

--- a/templates/layouts/petition-and-scroll-to-share.liquid
+++ b/templates/layouts/petition-and-scroll-to-share.liquid
@@ -3,7 +3,7 @@
 
 {% include 'Small Header' %}
 
-<div class="center-content center-content--accomodates-stuck-footer petition-and-scroll-to-share__sidebar">
+<div class="center-content center-content--accomodates-stuck-footer">
   <div class="center-content__big-column">
     <div class="mobile-show pre-main-bar">{% include 'Thermometer' %}</div>
 
@@ -14,13 +14,41 @@
   </div>
 </div>
 
-<div class="center-content center-content--accomodates-stuck-footer petition-and-scroll-to-share__share-wrapper">
+<div class="center-content center-content--accomodates-stuck-footer petition-and-scroll-to-share__yes-no-question-wrapper">
   <div class="center-content__one-column">
 
     <div class="center-content__central-square">
 
       {% capture message %}{{ 'petition.thank_you' | val: 'petition_title', title | t }}{% endcapture %}
       <h1 class="thank-you__thanks">{{ message }}</h1>
+      <div class="thank-you__cta">
+        <span class="two-step__question">{{ 'share.two_step.cta' | t }}</span>
+        <span class="two-step__declined hidden-closed">{{ 'share.two_step.declined' | t }}</span>
+        <span class="two-step__accepted hidden-closed">{{ 'share.two_step.accepted' | t }}</span>
+      </div>
+
+      <div class="center-content__centered-element">
+        <div class="two-step__question">
+          <div class="share-buttons">
+            <div class="share-buttons__button button two-step__button two-step__accept">
+              {{ 'share.two_step.accept' | t }}
+            </div>
+            <div class="share-buttons__button button two-step__button two-step__decline">
+              {{ 'share.two_step.decline' | t }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<div class="center-content center-content--accomodates-stuck-footer petition-and-scroll-to-share__share-wrapper">
+  <div class="center-content__one-column">
+
+    <div class="center-content__central-square">
+
       <div class="thank-you__cta">{{ 'share.cta' | t }}</div>
 
       <div class="center-content__centered-element">
@@ -36,17 +64,38 @@
 
 <script type="text/javascript">
   $(document).ready(function(){
-    var callback = function(e, data) {
-      var petitionSidebar = $('.center-content__fixed-right');
-      var bottomShare = $('.petition-and-scroll-to-share__share-wrapper');
-      petitionSidebar.fadeOut();
-      bottomShare.fadeIn();
-      $('html, body').animate({scrollTop: bottomShare.offset().top}, 800);
-    }
+    var petitionSidebar = $('.center-content__fixed-right');
+    var yesNoQuestion = $('.petition-and-scroll-to-share__yes-no-question-wrapper');
+    var shareStep = $('.petition-and-scroll-to-share__share-wrapper');
 
     new window.champaign.Petition({
       redirectAfterAction: false,
-      submissionCallback: callback
+      submissionCallback: petitionCallback
     });
+
+    $('.two-step__accept').click(displayAndScrollToShare);
+    $('.two-step__decline').click(displayAndScrollToDonate);
+
+    function petitionCallback(e, data) {
+      petitionSidebar.fadeOut();
+      yesNoQuestion.css('margin-bottom', window.innerHeight - yesNoQuestion.height());
+      yesNoQuestion.fadeIn();
+      scrollTo(yesNoQuestion);
+    }
+
+    function displayAndScrollToShare() {
+      shareStep.fadeIn();
+      shareStep.css('margin-bottom', window.innerHeight - shareStep.height());
+      scrollTo(shareStep);
+    }
+
+    function displayAndScrollToDonate() {
+      alert('donate');
+    }
+
+    function scrollTo(element) {
+      $('html, body').animate({scrollTop: element.offset().top}, 800);
+    }
+
   });
 </script>

--- a/templates/layouts/petition-and-scroll-to-share.liquid
+++ b/templates/layouts/petition-and-scroll-to-share.liquid
@@ -86,7 +86,7 @@
 
     function makeStepFullScreen(stepElement) {
       var offset = 35;
-      var padding = parseInt(stepElement.css('padding-top'));
+      var padding = parseInt(stepElement.css('padding-top'), 10);
       var totalElementHeight = stepElement.height() + padding + offset
       if (totalElementHeight < window.innerHeight) {
         stepElement.css('margin-bottom', window.innerHeight - totalElementHeight);

--- a/templates/layouts/petition-with-large-image.liquid
+++ b/templates/layouts/petition-with-large-image.liquid
@@ -16,3 +16,11 @@
 
 {% include 'Petition Mobile Footer' %}
 {% include 'Simple Footer' %}
+
+<script type="text/javascript">
+  $(document).ready(function(){
+    new window.champaign.Petition(
+      {followUpUrl: "{{ follow_up_url }}"}
+    );
+  });
+</script>

--- a/templates/layouts/petition-with-small-image.liquid
+++ b/templates/layouts/petition-with-small-image.liquid
@@ -2,3 +2,11 @@
 {% comment %} Primary layout: true {% endcomment %}
 
 {% include 'Petition With Small Image' %}
+
+<script type="text/javascript">
+  $(document).ready(function(){
+    new window.champaign.Petition(
+      {followUpUrl: "{{ follow_up_url }}"}
+    );
+  });
+</script>

--- a/templates/layouts/petition-with-title-below-image.liquid
+++ b/templates/layouts/petition-with-title-below-image.liquid
@@ -11,3 +11,11 @@
     display: block !important;
   }
 </style>
+
+<script type="text/javascript">
+  $(document).ready(function(){
+    new window.champaign.Petition(
+      {followUpUrl: "{{ follow_up_url }}"}
+    );
+  });
+</script>

--- a/templates/layouts/petition-without-image.liquid
+++ b/templates/layouts/petition-without-image.liquid
@@ -21,3 +21,11 @@
 
 {% include 'Petition Mobile Footer' %}
 {% include 'Small Image Footer' %}
+
+<script type="text/javascript">
+  $(document).ready(function(){
+    new window.champaign.Petition(
+      {followUpUrl: "{{ follow_up_url }}"}
+    );
+  });
+</script>

--- a/templates/partials/_petition_sidebar.liquid
+++ b/templates/partials/_petition_sidebar.liquid
@@ -53,11 +53,10 @@
           prefill:          true
         });
 
-        chmp.myPetition      = new chmp.Petition({followUpUrl: "{{ follow_up_url }}"});
         chmp.myOverlayToggle = new chmp.OverlayToggle();
         chmp.myThermometer   = new chmp.Thermometer(window.champaign.personalization.thermometer);
         chmp.mySidebar       = new chmp.Sidebar({petitionTextMinHeight: 120, baseClass: 'petition-bar'});
-        
+
         window.champaign.mySticky = new window.champaign.DesktopSticky({extra_class: 'petition'});
       });
     </script>

--- a/translations/sumofus.de.yml
+++ b/translations/sumofus.de.yml
@@ -60,6 +60,8 @@ de:
     thanks: 'Vielen Dank für Ihre Spende!'
   share_and_donate:
     fundraiser_title: 'Unterstützen Sie die Kampagnen von SumOfUs jetzt mit einer Spende!'
+  petition_and_scroll:
+    fundraiser_intro: 'Vielen Dank für Ihre Hilfe! Damit wir auch weiterhin dafür kämpfen können, dass Menschen wichtiger sind als Profite, brauchen wir Ihre Hilfe: Denn SumOfUs wird komplett von Mitgliedern wie Ihnen finanziert.'
   footer:
     home: Start
     about: Über Uns

--- a/translations/sumofus.en.yml
+++ b/translations/sumofus.en.yml
@@ -60,6 +60,8 @@ en:
     thanks: 'Thank you for your donation!'
   share_and_donate:
     fundraiser_title: 'Can you chip in to help fund SumOfUs’ campaigning?'
+  petition_and_scroll:
+    fundraiser_intro: 'Many thanks for your help! To help us continue to fight for people to be more important than profits, we need your help: SumOfUs is funded entirely by members like you.'
   footer:
     home: Home
     about: About

--- a/translations/sumofus.fr.yml
+++ b/translations/sumofus.fr.yml
@@ -60,6 +60,8 @@ fr:
     thanks: 'Merci pour votre don !'
   share_and_donate:
     fundraiser_title: 'Pouvez-vous faire un don afin de financer les campagnes de SumOfUs?'
+  petition_and_scroll:
+    fundraiser_intro: '<TranslationMissing> Many thanks for your help! To help us continue to fight for people to be more important than profits, we need your help: SumOfUs is funded entirely by members like you.'
   footer:
     home: Accueil
     about: Nous connaître


### PR DESCRIPTION
Refactored _petition_sidebar partial to not instantiate the Petition
widget. Every template that needs to use the petition widget needs to
instantiate it manually. This brings a little bit of duplication but
allows for greater flexibility.

Implemented the "petition and scroll" template per Joe experiments.

![petition scroll mobile](https://user-images.githubusercontent.com/278462/29583257-e5232b60-8755-11e7-8662-dc9a899b47f3.gif)

![petition scroll desktop](https://user-images.githubusercontent.com/278462/29583262-e9d9e1b2-8755-11e7-9b8a-9f0841cf3214.gif)

