### PR TITLE
Updating the string "chip in to help..."

### DIFF
--- a/translations/sumofus.de.yml
+++ b/translations/sumofus.de.yml
@@ -71,7 +71,7 @@ de:
       declined: "Kein Problem. Vielen Dank für Ihre Unterstützung!"
     thanks: "Vielen Dank für Ihre Spende!"
   share_and_donate:
-    fundraiser_title: "Jetzt spenden und SumOfUs 2019 unterstützen!"
+    fundraiser_title: "Jetzt spenden und SumOfUs unterstützen!"
   petition_and_scroll:
     fundraiser_intro: "Vielen Dank -- Sie sind großartig! SumOfUs wird komplett von Mitgliedern wie Ihnen finanziert."
   footer:

--- a/translations/sumofus.en.yml
+++ b/translations/sumofus.en.yml
@@ -42,11 +42,11 @@ en:
       cta:
         "<p><span class='inject-name'>Dear friend</span>, we need your support today to win campaigns against corporate power in 2019</p>
         <br/>
-        <p>Can you chip in to help power SumOfUs into 2019?</p>"
+        <p>Can you chip in to help power SumOfUs?</p>"
       cta_eoy:
         "<p><b><span class='inject-name'>Dear friend</span>, we're <span class='donations-thermometer-remainder'></span> short of our end of year fundraising goal.</b> We need your support today to win campaigns against corporate power in 2019.
         <br/>
-        <p>Can you chip in to help power SumOfUs into 2019?</p>"
+        <p>Can you chip in to help power SumOfUs?</p>"
   petition:
     sign_it: Sign the petition
     target_prefix: TO
@@ -71,7 +71,7 @@ en:
       declined: "No problem. Thanks for your support!"
     thanks: "Thank you for your donation!"
   share_and_donate:
-    fundraiser_title: Chip in to help power SumOfUs into 2019
+    fundraiser_title: Chip in to help power SumOfUs
   petition_and_scroll:
     fundraiser_intro: "Thank you - you are incredible! SumOfUs is funded entirely by members like you."
   footer:

--- a/translations/sumofus.es.yml
+++ b/translations/sumofus.es.yml
@@ -72,7 +72,7 @@ es:
       declined: "No problem. Thanks for your support!"
     thanks: "¡Gracias por tu donación!"
   share_and_donate:
-    fundraiser_title: "Ayuda a financiar las campañas de SumOfUs en 2019"
+    fundraiser_title: "Ayuda a financiar las campañas de SumOfUs"
   petition_and_scroll:
     fundraiser_intro: "¡Gracias, eres increíble! SumOfUs se financia íntegramente mediante miembros como tú."
   footer:

--- a/translations/sumofus.fr.yml
+++ b/translations/sumofus.fr.yml
@@ -71,7 +71,7 @@ fr:
       declined: "Merci d'avoir signé la pétition ! "
     thanks: "Merci pour votre don !"
   share_and_donate:
-    fundraiser_title: "Faire un don pour aider à renforcer SumOfUs en 2019"
+    fundraiser_title: "Faire un don pour aider à renforcer SumOfUs"
   petition_and_scroll:
     fundraiser_intro: "Merci, vous êtes fantastique ! SumOfUs est un mouvement financé par des personnes comme vous."
   footer:


### PR DESCRIPTION
I've removed the reference to 2019 in the EN, DE, FR and ES yml files, where we ask for a donation "chip in to help power SumOfUs"... cause it's March, so it's obviously a donation for 2019. ;-)

I also updated the footer of our website, where it said (c) 2017, to now say (c) 2019. I made that change in champaign. Just making a record of it here FYI.