### PR TITLE
Add FB events and alter donation event in scrolling pages

### DIFF
--- a/templates/layouts/Default:-petition-and-scroll-to-donate-greenpeace.liquid
+++ b/templates/layouts/Default:-petition-and-scroll-to-donate-greenpeace.liquid
@@ -89,6 +89,11 @@
     }
 
     function petitionCallback(e, data) {
+      fbq("track", "CompleteRegistration");
+      var state = champaign.myPetition.store.getState();
+      if (state.consent.consented && state.member === null) {
+        fbq("track", "Lead");
+      }
       petitionSidebar.fadeOut();
       petitionOverlayButton.fadeOut();
       displayAndScrollToYesNoQuestion();
@@ -124,7 +129,7 @@
 
     window.ee.on('fundraiser:transaction_success', function(responseData, formData) {
       var fundraiserData = champaign.store.getState().fundraiser;
-      fbq('track', 'CompleteRegistration', {
+      fbq('track', 'Donate', {
         registered_member: champaign.personalization.member.registered,
         currency: fundraiserData.currency,
         value: fundraiserData.donationAmount

--- a/templates/layouts/Default:-petition-and-scroll-to-share-greenpeace.liquid
+++ b/templates/layouts/Default:-petition-and-scroll-to-share-greenpeace.liquid
@@ -142,6 +142,11 @@ endcomment %} {% comment %} Primary layout: true {% endcomment %}
     }
 
     function petitionCallback(e, data) {
+      fbq("track", "CompleteRegistration");
+      var state = champaign.myPetition.store.getState();
+      if (state.consent.consented && state.member === null) {
+        fbq("track", "Lead");
+      }
       petitionSidebar.fadeOut();
       petitionOverlayButton.fadeOut();
       displayAndScrollToYesNoQuestion();
@@ -176,7 +181,7 @@ endcomment %} {% comment %} Primary layout: true {% endcomment %}
       formData
     ) {
       var fundraiserData = champaign.store.getState().fundraiser;
-      fbq("track", "CompleteRegistration", {
+      fbq("track", "Donate", {
         registered_member: champaign.personalization.member.registered,
         currency: fundraiserData.currency,
         value: fundraiserData.donationAmount


### PR DESCRIPTION
- New FB event "CompleteRegistration" when signing a petition
- New FB event "Lead" when a new member consents to communications
- Alter donation complete event from "CompleteRegistration" to "Donate" (new standard event type)
